### PR TITLE
OAuth2 implicit grant endpoint

### DIFF
--- a/app/app-config.coffee
+++ b/app/app-config.coffee
@@ -116,6 +116,11 @@ config = (
     template   : require('./views/connect/sso-callback')()
     controller : 'SSOCallbackController as vm'
     public: true
+
+  states['UNAUTHORIZED'] =
+    url: '/401',
+    template   : require('./views/401')()
+    public: true
   
   # This must be the last one in the list
   states['otherwise'] =

--- a/app/app-config.coffee
+++ b/app/app-config.coffee
@@ -58,9 +58,14 @@ config = (
     controller  : 'LogoutController as vm'
     template: require('./views/logout')()
     public: true
-
+  
+  states['OAUTH'] =
+    url: '/oauth?client_id&response_type&state&redirect_uri&scope'
+    controller  : 'OAuthController as vm'
+    public: true
+  
   states['MEMBER_LOGIN'] =
-    url: '/tc?retUrl&handle&password&return_to'
+    url: '/tc?retUrl&handle&password&return_to&client_id&response_type&state&redirect_uri&scope'
     controller  : 'TCLoginController as vm'
     template: require('./views/tc/login')()
     public: true

--- a/app/scripts/oauth.controller.coffee
+++ b/app/scripts/oauth.controller.coffee
@@ -1,0 +1,88 @@
+'use strict'
+
+{ getToken, validateClient } = require '../../core/auth.js'
+{ isUrl } = require '../../core/url.js'
+
+OAuthController = (
+  $log
+  $state
+  $stateParams
+  $window
+) ->
+  
+  vm = this
+
+  # /oauth?client_id&response_type&state&redirect_uri&scope  
+  validateParams = ->
+    error = undefined
+    if !$stateParams.response_type || $stateParams.response_type != 'token'
+      error = {type:'unsupported_response_type', desc:'response_type is invalid'}
+    else if !$stateParams.redirect_uri || !isUrl($stateParams.redirect_uri)
+      $stateParams.redirect_uri = undefined
+      error = {type:'invalid_request', desc:'redirect_uri is invalid'}
+    else if !$stateParams.client_id
+      error = {type:'invalid_request', desc:'client_id is required'}
+    
+    if error
+      $window.location.href = createErrorUrl($stateParams.redirect_uri || '/', error.type, error.desc, $stateParams.state || '')
+    error
+  
+  #access_token=&token_type=bearer&state
+  createRedirectUrl = (redirectUrl, state) ->
+    url = redirectUrl + '#access_token=' + getToken() + '&token_type=bearer&state=' + state
+    return url
+  
+  createErrorUrl = (redirectUrl, status, message, state) ->
+    ###
+    https://tools.ietf.org/html/rfc6749#page-26
+    400: 'invalid_request'
+    401: 'access_denied'
+    403: 'unauthorized_client'
+    500: 'server_error'
+    unsupported_response_type, invalid_scope,  
+    ###
+    error = ''
+    if status == 400
+      error = 'invalid_request'
+    else if status == 401
+      error = 'access_denied'
+    else if status == 403
+      error = 'unauthorized_client'
+    else if status >= 500
+      error = 'server_error'
+    else
+      error = status
+    
+    url = redirectUrl + '#error=' + error + '&error_description=' + message + '&state=' + state
+    return url
+  
+  init = ->
+    err = validateParams()
+    if err
+      return vm
+    
+    unless getToken()
+      $state.go 'MEMBER_LOGIN', $stateParams
+    else
+      redirectUrl = $stateParams.redirect_uri || ''
+      state = $stateParams.state || ''
+      clientId = $stateParams.client_id || ''
+      validateClient(clientId, redirectUrl)
+        .then (res) ->
+          $window.location.href = createRedirectUrl(redirectUrl, state)
+        .catch (err) ->
+          $log.error(err)
+          $window.location.href = createErrorUrl(redirectUrl, err?.response?.status, err?.message, state)
+    vm
+  
+  init()
+  
+
+OAuthController.$inject = [
+  '$log'
+  '$state'
+  '$stateParams'
+  '$window'
+]
+
+angular.module('accounts').controller 'OAuthController', OAuthController

--- a/app/scripts/tc/login.controller.coffee
+++ b/app/scripts/tc/login.controller.coffee
@@ -1,8 +1,7 @@
 'use strict'
 
-{ TC_JWT, ZENDESK_JWT, DOMAIN } = require '../../../core/constants.js'
-{ login, socialLogin }  = require '../../../core/auth.js'
-{ getToken }            = require '../../../core/token.js'
+{ DOMAIN } = require '../../../core/constants.js'
+{ login, socialLogin, getToken } = require '../../../core/auth.js'
 { isEmail, setupLoginEventMetrics } = require '../../../core/utils.js'
 { redirectTo, generateZendeskReturnUrl, generateReturnUrl } = require '../../../core/url.js'
 
@@ -102,19 +101,23 @@ TCLoginController = (
     # setup login event for analytics tracking
     setupLoginEventMetrics(vm.username)
 
-    if $stateParams.return_to
+    if $stateParams.redirect_uri
+      # OAuth
+      $state.go 'OAUTH', $stateParams
+    else if $stateParams.return_to
+      # Zendesk
       redirectTo generateZendeskReturnUrl($stateParams.return_to)
     else if vm.retUrl
       redirectTo generateReturnUrl(vm.retUrl)
     else
-        $state.go 'home'
+      $state.go 'home'
 
   init = ->
     # "return_to" is handed by Zendesk.
     # It's in the case of sign-in or session is expired in Zendesk. It always needs to log in.
     if $stateParams.return_to
       vm
-    else if getToken(TC_JWT) && vm.retUrl
+    else if getToken() && vm.retUrl
       redirectTo generateReturnUrl(vm.retUrl)
     else if ($stateParams.handle || $stateParams.email) && $stateParams.password
       id = $stateParams.handle || $stateParams.email

--- a/app/views/401.jade
+++ b/app/views/401.jade
@@ -1,0 +1,2 @@
+main.layout-main("role"="main" flush-height=true)
+  h1 401 - Unauthorized 

--- a/core/auth.js
+++ b/core/auth.js
@@ -354,10 +354,15 @@ export function getSSOProvider(handle) {
     .then(success)
 }
 
-export function validateClient(clientId, encodedRedirectUrl) {
-  const url = API_URL + '/v3/authorizations/validateClient?clientId=' + clientId + '&rediectUrl=' + encodedRedirectUrl
-  //const url = 'http://local.topcoder-dev.com:8080/v3/authorizations/validateClient?clientId=' + clientId + '&redirectUrl=' + encodedRedirectUrl
+export function validateClient(clientId, redirectUrl, scope) {
+
+  const token = getToken() || ''
+  const url = API_URL + '/v3/authorizations/validateClient?clientId=' + clientId + '&rediectUrl=' + encodeURIComponent(redirectUrl) + '&scope=' + scope
+  
   return fetchJSON(url, {
-    method: 'GET'
+    method: 'GET',
+    headers: {
+      Authorization: 'Bearer ' + token
+    }
   })
 }

--- a/core/auth.js
+++ b/core/auth.js
@@ -353,3 +353,11 @@ export function getSSOProvider(handle) {
     .catch(failure)
     .then(success)
 }
+
+export function validateClient(clientId, encodedRedirectUrl) {
+  const url = API_URL + '/v3/authorizations/validateClient?clientId=' + clientId + '&rediectUrl=' + encodedRedirectUrl
+  //const url = 'http://local.topcoder-dev.com:8080/v3/authorizations/validateClient?clientId=' + clientId + '&redirectUrl=' + encodedRedirectUrl
+  return fetchJSON(url, {
+    method: 'GET'
+  })
+}


### PR DESCRIPTION
### Task: [Accounts app to handle login with cliend-id](https://app.asana.com/0/100297043256537/115716817869791)

**Request**
```
https://accounts.topcoder.com/oauth?
     client_id={CLIENT-ID}
    &response_type=token
    &redirect_uri={REDIRECT-URI}
    &state={STATE}
    &scope={SCOPE}
```
*Parameters:*
- client_id: (required) ID for a client which is registered in the client database.
- response_type: (required) "token"
- redirect_uri: (required) Encoded URL to redirect after authentication. This should be registered in the client database.
- state:  (optional) 
- scope: (optional) placeholder

**Response**
```
{redirect_uri}#access_token={JWT}&token_type=bearer&state={STATE}
```
*Parameters:*
- access_token: JWT(Jason Web Token) issued by Identity Service.
- token_type: bearer
- state: This should be the same value specified in the request.


### TODO
- Member site login page is always shown for authentication. This means users can't login with SSO.
- Currently showing "401 Unauthorized" page in the accounts site for all errors caused during the process.
- "scope" is just a placeholder for future requirements.
- Authentication code grant will be required?

### APPENDIX
[RFC6749#Implicit Grant](https://tools.ietf.org/html/rfc6749#section-4.2)
