### PR TITLE
added auth0UserId to context param in social registration

### DIFF
--- a/app/scripts/tc/register.controller.js
+++ b/app/scripts/tc/register.controller.js
@@ -66,7 +66,8 @@ import { npad } from '../../../core/utils.js'
           providerType: vm.socialProvider,
           context: {
             handle: vm.username,
-            accessToken: vm.socialContext.accessToken
+            accessToken: vm.socialContext.accessToken,
+            auth0UserId: vm.socialProfile.user_id
           }
         }
       }


### PR DESCRIPTION
Fix for [Auth0 migration "Identity Provider access tokens removed from user profile and id_token"](https://app.asana.com/0/search/189603026493478/163129582694726)


Fix in Identity service:
https://github.com/appirio-tech/tc1-api-core/pull/235