### PR TITLE
fix origin checking

### DIFF
--- a/connector/connector-embed.js
+++ b/connector/connector-embed.js
@@ -1,10 +1,17 @@
 import 'babel-polyfill'
 
-import { GET_FRESH_TOKEN_REQUEST, GET_FRESH_TOKEN_SUCCESS, GET_FRESH_TOKEN_FAILURE, LOGOUT_REQUEST, LOGOUT_SUCCESS, LOGOUT_FAILURE } from '../core/constants.js'
+import { GET_FRESH_TOKEN_REQUEST, GET_FRESH_TOKEN_SUCCESS, GET_FRESH_TOKEN_FAILURE, LOGOUT_REQUEST, LOGOUT_SUCCESS, LOGOUT_FAILURE, ALLOWED_ORIGINS } from '../core/constants.js'
 import { getFreshToken, logout } from '../core/auth.js'
 
 function bindHandler(REQUEST, SUCCESS, FAILURE, action) {
   window.addEventListener('message', (e) => {
+
+    var origin = e.origin || e.originalEvent.origin;
+    if (ALLOWED_ORIGINS.indexOf(origin) === -1) {
+      console.error(origin, 'is not allowed');
+      return;
+    }
+
     function success(data) {
       const response = Object.assign({
         type: SUCCESS

--- a/connector/connector-wrapper.js
+++ b/connector/connector-wrapper.js
@@ -38,17 +38,9 @@ const proxyCall = function(REQUEST, SUCCESS, FAILURE, params = {}) {
   function request() {
     return new Promise( (resolve, reject) => {
       function receiveMessage(e) {
-        // ignore anything that is not our message
-        // check origin and more strict message format
-        var origin = e.origin || e.originalEvent.origin;
-        const safeOrigin = origin && origin.endsWith(DOMAIN)
-        const safeFormat = e.data.type === SUCCESS || e.data.type === FAILURE
-        if (safeOrigin && safeFormat) {
-          window.removeEventListener('message', receiveMessage)
-
-          if (e.data.type === SUCCESS) resolve(e.data)
-          if (e.data.type === FAILURE) reject(e.error)
-        }
+        window.removeEventListener('message', receiveMessage)
+        if (e.data.type === SUCCESS) resolve(e.data)
+        if (e.data.type === FAILURE) reject(e.error)
       }
 
       window.addEventListener('message', receiveMessage)

--- a/core/constants.js
+++ b/core/constants.js
@@ -21,3 +21,5 @@ export const LOGOUT_SUCCESS = 'LOGOUT_SUCCESS'
 export const LOGOUT_FAILURE = 'LOGOUT_FAILURE'
 
 export const BUSY_PROGRESS_MESSAGE = 'Processing...'
+
+export const ALLOWED_ORIGINS = [DOMAIN, 'http://localhost:3000']


### PR DESCRIPTION
It will report an error:
![Alt text](https://monosnap.com/file/rMNny9b2iTvHWKIJXziy5a6hp2my5x.png)

domain: `localhost:3000` is always allowed
it can be disabled for production, but we need that when developing TC Connect locally.