### PR TITLE
Github issue #490 General: Connect links leading to blank page

### DIFF
--- a/connector/connector-wrapper.js
+++ b/connector/connector-wrapper.js
@@ -38,9 +38,12 @@ const proxyCall = function(REQUEST, SUCCESS, FAILURE, params = {}) {
   function request() {
     return new Promise( (resolve, reject) => {
       function receiveMessage(e) {
-        window.removeEventListener('message', receiveMessage)
-        if (e.data.type === SUCCESS) resolve(e.data)
-        if (e.data.type === FAILURE) reject(e.error)
+        const safeFormat = e.data.type === SUCCESS || e.data.type === FAILURE
+        if (safeFormat) {
+          window.removeEventListener('message', receiveMessage)
+          if (e.data.type === SUCCESS) resolve(e.data)
+          if (e.data.type === FAILURE) reject(e.error)
+        }
       }
 
       window.addEventListener('message', receiveMessage)


### PR DESCRIPTION
-- Fixed the issue. It appeared because one of the security fix, removed safe format check which is required to ignore non interesting events. One such example is cache event which happens to be thrown after session inactivity for some time and because we are not checking for the safe format, current code removes the callback listener and when actually we receive jwt token from accounts app, we don't have the listener to act on that, causing blank screens.

@ajefts @sudoster fyi, please let me know if you see any troubles with this fix.