### PR TITLE
Modified the error message when SSO users try to rest password

### DIFF
--- a/app/scripts/tc/reset-password.controller.js
+++ b/app/scripts/tc/reset-password.controller.js
@@ -21,7 +21,7 @@ import { DOMAIN } from '../../../core/constants.js'
       vm.alreadySent = false
       vm.emailNotFound = false
       vm.unableToRest = false
-      vm.resetError = false
+      vm.unkownError = false
     }
     vm.clearState()
 
@@ -45,6 +45,8 @@ import { DOMAIN } from '../../../core/constants.js'
                 vm.unableToRest = true
               else if (err.status == 404)
                 vm.emailNotFound = true
+              else
+                vm.unkownError = true
 
               vm.resetTokenFailed = true
               vm.loading = false

--- a/app/views/tc/reset-password.jade
+++ b/app/views/tc/reset-password.jade
@@ -31,8 +31,7 @@
       p.form-error(ng-show="vm.emailNotFound") We couldn't find a member with that email address. Please check that you entered it correctly. If you continue to have trouble, please contact&nbsp;
         a(href="mailto:support@topcoder.com?Subject=Unable%20to%20reset%20my%20password" target="_top") support@topcoder.com
 
-      p.form-error(ng-show="vm.unableToRest") We were unable to send you a reset link because your account is not allowed to reset password. If you continue to have trouble, please contact&nbsp;
-        a(href="mailto:support@topcoder.com?Subject=Unable%20to%20reset%20my%20password" target="_top") support@topcoder.com
+      p.form-error(ng-show="vm.unableToRest") We were unable to send you a reset link because your account is not allowed to reset password. If you are using Single Sign On, please follow the instructions of your SSO account to reset password.
 
       p.form-error(ng-show="vm.unkownError") We were unable to send you a reset link because of a temporary problem. Please try again. If you continue to have trouble, please contact&nbsp;
         a(href="mailto:support@topcoder.com?Subject=Unable%20to%20reset%20my%20password" target="_top") support@topcoder.com


### PR DESCRIPTION
Message
```
We were unable to send you a reset link because your account is not allowed to reset password. If you are using Single Sign On, please follow the instructions of your SSO account to reset password.
```