### PR TITLE
Revert change in connector-wrapper.js (was reverted in master in 2016)

### DIFF
--- a/connector/connector-wrapper.js
+++ b/connector/connector-wrapper.js
@@ -38,12 +38,9 @@ const proxyCall = function(REQUEST, SUCCESS, FAILURE, params = {}) {
   function request() {
     return new Promise( (resolve, reject) => {
       function receiveMessage(e) {
-        const safeFormat = e.data.type === SUCCESS || e.data.type === FAILURE
-        if (safeFormat) {
-          window.removeEventListener('message', receiveMessage)
-          if (e.data.type === SUCCESS) resolve(e.data)
-          if (e.data.type === FAILURE) reject(e.error)
-        }
+        window.removeEventListener('message', receiveMessage)
+        if (e.data.type === SUCCESS) resolve(e.data)
+        if (e.data.type === FAILURE) reject(e.error)
       }
 
       window.addEventListener('message', receiveMessage)


### PR DESCRIPTION
This commit to dev, will bring dev completely into sync with master. I realize there is some question on if we need this change - however, we've been running without it in master for over 6 months now. I'd recommend if we need it we add it back laster and get dev back in sync with master now.

This change was originally reverted in master on Dec 13th, 2016 (6f2bd9d).

@vikasrohit - please review.