### PR TITLE
Updating retUrl that is set in the activation email

### DIFF
--- a/app/scripts/tc/register.controller.js
+++ b/app/scripts/tc/register.controller.js
@@ -10,7 +10,7 @@ import { getNewJWT } from '../../../core/auth.js'
 (function() {
   'use strict'
 
-  const SKILL_PICKER_URL = 'https://www.' + DOMAIN + '/skill-picker'
+  const SKILL_PICKER_URL = 'https://www.' + DOMAIN + '/settings/profile'
 
   angular.module('accounts').controller('TCRegistrationController', TCRegistrationController)
 


### PR DESCRIPTION
We are deprecating the skill picker page now that we're releasing the new user settings pages.  We will direct the user to their user settings after activation by default.