### PR TITLE
login/signup ui update

### DIFF
--- a/app/scripts/connect/pin-registration.controller.coffee
+++ b/app/scripts/connect/pin-registration.controller.coffee
@@ -202,10 +202,11 @@ ConnectPinVerificationController = (
           $scope.$apply ->
             vm.emailEditMode = false
             vm.loading = false
-            vm.emailEditSuccess = true
+            vm.resendPinSuccess = true
             vm.reRender()
       )
       .catch(resendPinFailure)
+    vm.reRender()
 
   # Handles error in resending pin
   resendPinFailure = (error) ->

--- a/app/scripts/connect/pin-registration.controller.coffee
+++ b/app/scripts/connect/pin-registration.controller.coffee
@@ -76,6 +76,7 @@ ConnectPinVerificationController = (
   # Handles the error in verifying/activating account
   resetPINFailure = ->
     $scope.$apply ->
+      vm.loading  = false
       vm.errorLimit = false
       vm.message = 'That PIN is incorrect. Please check that you entered the one you received.'
 
@@ -92,6 +93,15 @@ ConnectPinVerificationController = (
     # call login api
     login(options).then(loginSuccess, loginFailure)
 
+  goToWelcomePage = ->
+    $scope.$apply ->
+      vm.activated = false
+      vm.loggedIn = true
+    stateParams =
+        username: vm.$stateParams.username
+    $state.go 'CONNECT_WELCOME', stateParams
+    vm.reRender()
+
   # Handles the login success, redirects user to the return URL
   loginSuccess = ->
     jwt = getV3Jwt()
@@ -101,17 +111,9 @@ ConnectPinVerificationController = (
         vm.activated = false
         vm.error = true
         vm.message = 'Unable to log you in automatically. Please try login using login link.'
-    else if vm.retUrl
-      $scope.$apply ->
-        vm.activated = false
-        vm.loggedIn = true
-      redirectTo generateReturnUrl(vm.retUrl)
     else
-      $scope.$apply ->
-        vm.activated = false
-        vm.loggedIn = true
-      $state.go 'CONNECT_WELCOME'
-    vm.reRender()
+      goToWelcomePage()
+    
 
   # Handles login failure 
   loginFailure = ->
@@ -189,6 +191,32 @@ ConnectPinVerificationController = (
   # Call API to update user's meail
   updateEmail = (token) ->
     updatePrimaryEmail(vm.$stateParams.userId, vm.email, token)
+
+  # Call API to resend Activation code
+  vm.callResendPIN = () ->
+    vm.loading = true
+    vm.resendPIN()
+      .then(
+        () ->
+          console.log 'Successfully resent PIN'
+          $scope.$apply ->
+            vm.emailEditMode = false
+            vm.loading = false
+            vm.emailEditSuccess = true
+            vm.reRender()
+      )
+      .catch(resendPinFailure)
+
+  # Handles error in resending pin
+  resendPinFailure = (error) ->
+    # show error in the form
+    $scope.$apply ->
+      vm.error = true
+      vm.emailError = true
+      vm.message = 'Currently we can\'t send a new pin'
+      vm.loading = false
+      vm.emailEditMode = true
+      vm.reRender()
 
   # Call API to resend Activation code
   vm.resendPIN = () ->

--- a/app/scripts/connect/welcome.coffee
+++ b/app/scripts/connect/welcome.coffee
@@ -24,6 +24,8 @@ ConnectWelcomeController = ($state, $stateParams, $scope, ISO3166) ->
   vm.auth0Data    = $stateParams.auth0Data
   vm.screenType   = "welcome"
   vm.isLoggedIn      = false
+  vm.userHandle =  $stateParams.username
+  
   # SSO user data extracted from auth0 login data
   vm.ssoUser = vm.auth0Data?.ssoUserData
 

--- a/core/auth.js
+++ b/core/auth.js
@@ -38,7 +38,7 @@ function fetchJSON(url, options) {
           if (json.result.status >= 200 && json.result.status < 300) {
             return json
           } else {
-            if (json.result.success) {
+            if (json.result.success && json.result.status === 401) {
               return json
             }
             const error = new Error(json.result.content)


### PR DESCRIPTION
1. when entering the pin, user is redirected to connect, without showing the `select solution` screen. user is redirected to connect root page, not the /new-project route (I see the redirect is implemented correctly in the select solution screen, but the user is redirected before that screen is shown)
2. when entering a wrong pin, spinner is shown and user can't enter new pin
3. user info should move to the right https://www.screencast.com/t/YLe3r9oN
4. Let's remove the project outline section in step 3
5. Implement the right sidebar in step 3 - the info will differ for each project type (App, Website, etc) and will come from the api - api call to /metadata endpoint has response.projectTypes field (used for rendering step2) and we'll add imageUrl, subtitle, description, brochureURL to each project type