### PR TITLE
Removing consideration of 401 as success for refresh token call

### DIFF
--- a/core/auth.js
+++ b/core/auth.js
@@ -40,7 +40,7 @@ function fetchJSON(url, options) {
           if (json.result.status >= 200 && json.result.status < 300) {
             return json
           } else {
-            if (json.result.success && json.result.status === 401) {
+            if (json.result.success) {
               return json
             }
             const error = new Error(json.result.content)


### PR DESCRIPTION
fyi @mtwomey @RishiRajSahu @gondzo 

Patching the production to avoid empty screen errors. I think doing this might introduce the issue where entering wrong PIN was not showing the error message correctly and was not allowing entering the pin after words. But I think we need to first handle this empty screen error because it seems to be wide spread across the platform. And we might need to apply another patch for fixing the wrong pin case after this.